### PR TITLE
Case insensitive game code

### DIFF
--- a/app/game/index.ts
+++ b/app/game/index.ts
@@ -72,7 +72,7 @@ export async function createGameCode(gameId: string) {
 }
 
 export async function getGameId(gameCode: string) {
-  const gameId = await kv.get(gameCode)
+  const gameId = await kv.get(gameCode.toUpperCase())
 
   return gameId
 }


### PR DESCRIPTION
This pr makes the user entered game code uppercase to match the randomly generated codes which are always upper case.

I am incapable of testing thoroughly since I cannot use the vercel resources though.
<img width="1001" alt="Screenshot 2024-02-24 at 8 53 34 AM" src="https://github.com/cailyncodes/thavalon/assets/22599519/64c6bbdf-f7a3-4bbb-9e2b-858cd80a475b">
