### PR TITLE
Remake game button

### DIFF
--- a/app/game/[gameId]/GameManager.tsx
+++ b/app/game/[gameId]/GameManager.tsx
@@ -2,8 +2,13 @@
 import React from 'react'
 import { createGameCode, startGame } from '../index'
 
-export const GameManager = (props: { gameId: string, initialPlayers: string[] }) => {
-  const [players, setPlayers] = React.useState(props.initialPlayers);
+interface GameManagerProps {
+  gameId: string;
+  initialPlayers: string[];
+ }
+
+export const GameManager = ({ gameId, initialPlayers }: GameManagerProps) => {
+  const [players, setPlayers] = React.useState(initialPlayers);
 
   const addPlayer = (e: React.FormEvent) => {
     e.preventDefault();
@@ -18,10 +23,9 @@ export const GameManager = (props: { gameId: string, initialPlayers: string[] })
   }
 
   const startNewGame = async (_: FormData) => {
-    console.log("calling startNewGame with players: ", players)
-    await startGame({ gameId: props.gameId, players });
-    const gameCode = await createGameCode(props.gameId);
-    window.location.assign(`/game/${props.gameId}/view?gameCode=${gameCode}`);
+    await startGame({ gameId, players });
+    const gameCode = await createGameCode(gameId);
+    window.location.assign(`/game/${gameId}/view?gameCode=${gameCode}`);
   }
 
   return (

--- a/app/game/[gameId]/GameManager.tsx
+++ b/app/game/[gameId]/GameManager.tsx
@@ -2,8 +2,8 @@
 import React from 'react'
 import { createGameCode, startGame } from '../index'
 
-export const GameManager = (props: { gameId: string }) => {
-  const [players, setPlayers] = React.useState<string[]>([]);
+export const GameManager = (props: { gameId: string, initialPlayers: string[] }) => {
+  const [players, setPlayers] = React.useState(props.initialPlayers);
 
   const addPlayer = (e: React.FormEvent) => {
     e.preventDefault();

--- a/app/game/[gameId]/GameManager.tsx
+++ b/app/game/[gameId]/GameManager.tsx
@@ -18,6 +18,7 @@ export const GameManager = (props: { gameId: string, initialPlayers: string[] })
   }
 
   const startNewGame = async (_: FormData) => {
+    console.log("calling startNewGame with players: ", players)
     await startGame({ gameId: props.gameId, players });
     const gameCode = await createGameCode(props.gameId);
     window.location.assign(`/game/${props.gameId}/view?gameCode=${gameCode}`);

--- a/app/game/[gameId]/page.tsx
+++ b/app/game/[gameId]/page.tsx
@@ -3,10 +3,18 @@ import { GameManager } from "./GameManager";
 
 export default function GameHome({
   params,
+  searchParams,
 }: {
-  params: { gameId: string };
+  params: { gameId: string};
+  searchParams: { [key: string]: string | string[] | undefined }
 }) {
+  const initialPlayersParam = searchParams['initialPlayers']
+  let initialPlayers: string[] = []
+  if (Array.isArray(initialPlayersParam)) {
+    initialPlayers = initialPlayersParam
+  }
+
   return (
-    <GameManager gameId={params.gameId} />
+    <GameManager gameId={params.gameId} initialPlayers={initialPlayers} />
   )
 }

--- a/app/game/[gameId]/page.tsx
+++ b/app/game/[gameId]/page.tsx
@@ -8,7 +8,7 @@ export default function GameHome({
   params: { gameId: string};
   searchParams: { [key: string]: string | string[] | undefined }
 }) {
-  const initialPlayersParam = searchParams['initialPlayers']
+  const initialPlayersParam = searchParams['initial_players[]']
   let initialPlayers: string[] = []
   if (Array.isArray(initialPlayersParam)) {
     initialPlayers = initialPlayersParam

--- a/app/game/[gameId]/view/RemakeGame.tsx
+++ b/app/game/[gameId]/view/RemakeGame.tsx
@@ -1,0 +1,27 @@
+"use client"
+import React from 'react'
+import { createGame } from '../../index';
+
+interface RemakeGameProps {
+  players: string[];
+ }
+
+export const RemakeGame = ({ players }: RemakeGameProps) => {
+    const remakeGame = async (_: FormData) => {
+        const newGameId = await createGame();
+        // add initial_players as an array of strings to the query params
+        let params = players.map((player) => 
+            `initial_players[]=${encodeURIComponent(player)}`
+        ).join('&');
+        window.location.assign(`/game/${newGameId}?${params}`);
+      }
+
+    return (
+    <div className="w-full flex flex-col items-center justify-between">
+    <form className="w-full max-w-lg flex justify-center items-center" action={remakeGame}>
+      <button className="bg-blue-500 hover:bg-blue-700 text-white font-bold py-2 px-4 rounded" type="submit">
+        Remake Game (beta)
+      </button>
+    </form>
+  </div>)
+}

--- a/app/game/[gameId]/view/page.tsx
+++ b/app/game/[gameId]/view/page.tsx
@@ -13,7 +13,11 @@ export default async function GameHome({
 
   const remakeGame = async (_: FormData) => {
     const newGameId = await createGame();
-    window.location.assign(`/game/${newGameId}?initialPlayers=${game.players.join(',')}`);
+    // add initial_players as an array of strings to the query params
+    let params = game.players.map((player) => 
+        `initial_players[]=${encodeURIComponent(player)}`
+    ).join('&');
+    window.location.assign(`/game/${newGameId}?${params}`);
   }
 
   return (

--- a/app/game/[gameId]/view/page.tsx
+++ b/app/game/[gameId]/view/page.tsx
@@ -1,34 +1,16 @@
-"use client"
-import { Game, createGame, getGame } from '../../index'
+import { getGame } from '../../index'
 import React from 'react'
+import { RemakeGame } from './RemakeGame'
 
-export default function GameHome({
+export default async function GameHome({
   params,
   searchParams
 }: {
   params: { gameId: string },
   searchParams: { [key: string]: string | string[] | undefined }
 }) {
-  const [game, setGame] = React.useState<Game>()
+  const game = await getGame(params.gameId)
   const gameCode = (searchParams['gameCode'] as string).toUpperCase()
-
-  React.useEffect(() => {
-    const fetchGame = async () => {
-      const gameData = await getGame(params.gameId)
-      setGame(gameData)
-    }
-    fetchGame()
-  }, []);
-
-  const remakeGame = async (_: FormData) => {
-    if (!game) return;
-    const newGameId = await createGame();
-    // add initial_players as an array of strings to the query params
-    let params = game.players.map((player) => 
-        `initial_players[]=${encodeURIComponent(player)}`
-    ).join('&');
-    window.location.assign(`/game/${newGameId}?${params}`);
-  }
 
   return (
     <main className="min-h-screen h-full flex flex-col items-center justify-center p-24">
@@ -52,13 +34,7 @@ export default function GameHome({
             ))}
           </div>
         </div>
-        <div className="w-full flex flex-col items-center justify-between">
-          <form className="w-full max-w-lg flex justify-center items-center" action={remakeGame}>
-            <button className="bg-blue-500 hover:bg-blue-700 text-white font-bold py-2 px-4 rounded" type="submit">
-              Remake Game (beta)
-            </button>
-          </form>
-        </div>
+        <RemakeGame players={game.players} />
       </div>
     }
     </main>

--- a/app/game/[gameId]/view/page.tsx
+++ b/app/game/[gameId]/view/page.tsx
@@ -1,17 +1,29 @@
-import { createGame, getGame } from '../../index'
+"use client"
+import { Game, createGame, getGame } from '../../index'
 import React from 'react'
 
-export default async function GameHome({
+export default function GameHome({
   params,
   searchParams
 }: {
   params: { gameId: string },
   searchParams: { [key: string]: string | string[] | undefined }
 }) {
-  const game = await getGame(params.gameId)
+
+  const [game, setGame] = React.useState<Game>()
   const gameCode = searchParams['gameCode']
 
+  // make useEffect to get the game data
+  React.useEffect(() => {
+    const fetchGame = async () => {
+      const gameData = await getGame(params.gameId)
+      setGame(gameData)
+    }
+    fetchGame()
+  }, [])
+
   const remakeGame = async (_: FormData) => {
+    if (!game) return;
     const newGameId = await createGame();
     // add initial_players as an array of strings to the query params
     let params = game.players.map((player) => 
@@ -22,6 +34,7 @@ export default async function GameHome({
 
   return (
     <main className="min-h-screen h-full flex flex-col items-center justify-center p-24">
+      {game && 
       <div className="max-w-5xl w-full font-mono text-sm flex flex-col">
         <div className="mb-12">
           <h1 className="text-lg">Players</h1>
@@ -42,12 +55,15 @@ export default async function GameHome({
             ))}
           </div>
         </div>
-        <form className="w-full max-w-lg flex justify-center items-center" action={remakeGame}>
-          <button className="bg-blue-500 hover:bg-blue-700 text-white font-bold py-2 px-4 rounded" type="submit">
-            Remake Game
-          </button>
-        </form>
+        <div className="w-full flex flex-col items-center justify-between">
+          <form className="w-full max-w-lg flex justify-center items-center" action={remakeGame}>
+            <button className="bg-blue-500 hover:bg-blue-700 text-white font-bold py-2 px-4 rounded" type="submit">
+              Remake Game
+            </button>
+          </form>
+        </div>
       </div>
+    }
     </main>
   )
 }

--- a/app/game/[gameId]/view/page.tsx
+++ b/app/game/[gameId]/view/page.tsx
@@ -13,14 +13,13 @@ export default function GameHome({
   const [game, setGame] = React.useState<Game>()
   const gameCode = searchParams['gameCode']
 
-  // make useEffect to get the game data
   React.useEffect(() => {
     const fetchGame = async () => {
       const gameData = await getGame(params.gameId)
       setGame(gameData)
     }
     fetchGame()
-  }, [])
+  }, []);
 
   const remakeGame = async (_: FormData) => {
     if (!game) return;

--- a/app/game/[gameId]/view/page.tsx
+++ b/app/game/[gameId]/view/page.tsx
@@ -47,7 +47,6 @@ export default function GameHome({
             <p className='text-md font-bold'>{game.start}</p>
           </div>
           <div className="flex flex-col justify-center items-center w-full mb-6 lg:mb-12">
-            {/* @ts-expect-error */}
             {game.players.map((player, index) => (
               <div key={index} className="flex flex-row justify-center items-center w-full mb-4">
                 <a href={`/game/${params.gameId}/view/${player}`} className="underline underline-offset-2">{player}</a>

--- a/app/game/[gameId]/view/page.tsx
+++ b/app/game/[gameId]/view/page.tsx
@@ -57,7 +57,7 @@ export default function GameHome({
         <div className="w-full flex flex-col items-center justify-between">
           <form className="w-full max-w-lg flex justify-center items-center" action={remakeGame}>
             <button className="bg-blue-500 hover:bg-blue-700 text-white font-bold py-2 px-4 rounded" type="submit">
-              Remake Game
+              Remake Game (beta)
             </button>
           </form>
         </div>

--- a/app/game/[gameId]/view/page.tsx
+++ b/app/game/[gameId]/view/page.tsx
@@ -1,4 +1,4 @@
-import { getGame } from '../../index'
+import { createGame, getGame } from '../../index'
 import React from 'react'
 
 export default async function GameHome({
@@ -10,6 +10,11 @@ export default async function GameHome({
 }) {
   const game = await getGame(params.gameId)
   const gameCode = searchParams['gameCode']
+
+  const remakeGame = async (_: FormData) => {
+    const newGameId = await createGame();
+    window.location.assign(`/game/${newGameId}?initialPlayers=${game.players.join(',')}`);
+  }
 
   return (
     <main className="min-h-screen h-full flex flex-col items-center justify-center p-24">
@@ -33,6 +38,11 @@ export default async function GameHome({
             ))}
           </div>
         </div>
+        <form className="w-full max-w-lg flex justify-center items-center" action={remakeGame}>
+          <button className="bg-blue-500 hover:bg-blue-700 text-white font-bold py-2 px-4 rounded" type="submit">
+            Remake Game
+          </button>
+        </form>
       </div>
     </main>
   )

--- a/app/game/index.ts
+++ b/app/game/index.ts
@@ -14,7 +14,7 @@ export interface Game extends ProtoGame{
   // starting player for proposing missions
   start: string;
   // games also have a mapping from player names to their roles
-  [player: string]: string | string[];
+  [player: string]: any;
 }
 
 export async function createGame() {

--- a/app/game/index.ts
+++ b/app/game/index.ts
@@ -3,9 +3,16 @@ import { put } from "@vercel/blob"
 import { kv } from "@vercel/kv";
 import { randomUUID } from "crypto";
 
-interface Game {
-  gameId: string,
-  players: string[],
+// Game data before running script to determine start player
+interface ProtoGame {
+  gameId: string;
+  players: string[];
+}
+
+// Game data with a specified start player
+export interface Game extends ProtoGame{
+  // starting player for proposing missions
+  start: string;
 }
 
 export async function createGame() {
@@ -25,7 +32,7 @@ export async function createGame() {
 }
 
 export async function startGame(data: { gameId: string, players: string[] }) {
-  const game: Game = {
+  const game: ProtoGame = {
     gameId: data.gameId,
     players: data.players,
   }
@@ -56,7 +63,7 @@ export async function startGame(data: { gameId: string, players: string[] }) {
 
 export async function getGame(gameId: string): Promise<Game> {
   const response = await fetch(
-    "https://kslx3eprjeoij69w.public.blob.vercel-storage.com/" + gameId + ".json",
+    process.env.DB_URL + gameId + ".json",
     {
       headers: {
         "content-type": "application/json",

--- a/app/game/index.ts
+++ b/app/game/index.ts
@@ -65,7 +65,7 @@ export async function startGame(data: { gameId: string, players: string[] }) {
 
 export async function getGame(gameId: string): Promise<Game> {
   const response = await fetch(
-    "https://spwamd4ap0dqqd0y.public.blob.vercel-storage.com/" + gameId + ".json",
+    "https://kslx3eprjeoij69w.public.blob.vercel-storage.com/" + gameId + ".json",
     {
       headers: {
         "content-type": "application/json",

--- a/app/game/index.ts
+++ b/app/game/index.ts
@@ -13,6 +13,8 @@ interface ProtoGame {
 export interface Game extends ProtoGame{
   // starting player for proposing missions
   start: string;
+  // games also have a mapping from player names to their roles
+  [player: string]: string | string[];
 }
 
 export async function createGame() {

--- a/app/game/index.ts
+++ b/app/game/index.ts
@@ -65,7 +65,7 @@ export async function startGame(data: { gameId: string, players: string[] }) {
 
 export async function getGame(gameId: string): Promise<Game> {
   const response = await fetch(
-    process.env.DB_URL + gameId + ".json",
+    "https://spwamd4ap0dqqd0y.public.blob.vercel-storage.com/" + gameId + ".json",
     {
       headers: {
         "content-type": "application/json",

--- a/app/game/index.ts
+++ b/app/game/index.ts
@@ -3,6 +3,11 @@ import { put } from "@vercel/blob"
 import { kv } from "@vercel/kv";
 import { randomUUID } from "crypto";
 
+interface Game {
+  gameId: string,
+  players: string[],
+}
+
 export async function createGame() {
   const gameId = randomUUID();
 
@@ -20,7 +25,7 @@ export async function createGame() {
 }
 
 export async function startGame(data: { gameId: string, players: string[] }) {
-  const game = {
+  const game: Game = {
     gameId: data.gameId,
     players: data.players,
   }
@@ -49,7 +54,7 @@ export async function startGame(data: { gameId: string, players: string[] }) {
   })
 }
 
-export async function getGame(gameId: string) {
+export async function getGame(gameId: string): Promise<Game> {
   const response = await fetch(
     "https://kslx3eprjeoij69w.public.blob.vercel-storage.com/" + gameId + ".json",
     {


### PR DESCRIPTION
We update the GameManager to accept a list of initialPlayers so that you can hit a button to remake the game and it will start populated. I think this is better than immediately starting the game with the same players since people might join/leave.

As for getting this list of players passed along, I think it's not unreasonable for it to be encoded as a list in the url that hits the GameHome page (which calls GameManager).

<img width="670" alt="Screenshot 2024-02-28 at 11 39 35 PM" src="https://github.com/cailyncodes/thavalon/assets/22599519/447c2699-9a32-4d48-b4b6-047e7d6eaf19">


Verification
- [x] needs to be tested
- [x] test that it works in prod by merging