### PR TITLE
Keep game code uppercase in the UI

### DIFF
--- a/app/game/[gameId]/view/page.tsx
+++ b/app/game/[gameId]/view/page.tsx
@@ -9,7 +9,7 @@ export default async function GameHome({
   searchParams: { [key: string]: string | string[] | undefined }
 }) {
   const game = await getGame(params.gameId)
-  const gameCode = searchParams['gameCode']
+  const gameCode = (searchParams['gameCode'] as string).toUpperCase()
 
   return (
     <main className="min-h-screen h-full flex flex-col items-center justify-center p-24">


### PR DESCRIPTION
Users complained about the lowercase characters showing up as lowercase on the page.  This changes the game code to be uppercase on the page.

We could make it so that the game code is changed to uppercase when entered in the form, but a user could still manually enter the code in the url and it should still be turned into uppercase. Although, that scenario is unlikely, so I am willing to change this pr.

<img width="568" alt="Screenshot 2024-02-28 at 9 33 00 PM" src="https://github.com/cailyncodes/thavalon/assets/22599519/c38a74e9-6b0d-4e72-b76c-4b66bf563ee6">
