### PR TITLE
Fix number of evils in nine player games

### DIFF
--- a/api/game.py
+++ b/api/game.py
@@ -184,7 +184,7 @@ def get_player_info(player_names):
     # number of good and evil roles
     if num_players < 7:
         num_evil = 2
-    elif num_players < 9:
+    elif num_players < 10:
         num_evil = 3
     else:
         num_evil = 4


### PR DESCRIPTION
According to the rules, 9 player games should have 3 evils, not 4.

<img width="849" alt="Screenshot 2024-03-03 at 10 59 46 AM" src="https://github.com/cailyncodes/thavalon/assets/22599519/b44bde13-f586-4a97-8574-05b841734e4d">

- [x] tested locally
