### PR TITLE
Switch to random 4 letter words for codes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -38,3 +38,6 @@ next-env.d.ts
 # python
 *.pyc
 __pycache__/
+
+# intellij
+.idea

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -9,5 +9,7 @@
     "**/Thumbs.db": true,
     "**/.next": true,
     "**/.gitkeep": true,
+    "api": true,
+    "client": true,
   }
 }

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -9,7 +9,5 @@
     "**/Thumbs.db": true,
     "**/.next": true,
     "**/.gitkeep": true,
-    "api": true,
-    "client": true,
   }
 }

--- a/client/app/game/index.ts
+++ b/client/app/game/index.ts
@@ -22,7 +22,7 @@ export interface Game extends ProtoGame {
 
 export async function createGame(host: string) {
   const gameId = randomUUID();
-  
+
   const file = new Blob([JSON.stringify({ gameId, host, players: [host] })], { type: "application/json" });
   await put(`${gameId}.json`, file, {
     access: 'public',

--- a/client/app/game/index.ts
+++ b/client/app/game/index.ts
@@ -22,7 +22,7 @@ export interface Game extends ProtoGame {
 
 export async function createGame(host: string) {
   const gameId = randomUUID();
-
+  
   const file = new Blob([JSON.stringify({ gameId, host, players: [host] })], { type: "application/json" });
   await put(`${gameId}.json`, file, {
     access: 'public',
@@ -58,8 +58,11 @@ export async function getGame(gameId: string): Promise<Game> {
 }
 
 export async function createGameCode(gameId: string) {
-  const code = "ABCDEFGHIJKLMNPQRSTUVWXYZ123456789"
-  const gameCode = code.split('').sort(() => Math.random() - 0.5).slice(0, 4).join('')
+  // see https://random-word-api.vercel.app/
+  const response = await fetch(
+    'https://random-word-api.vercel.app/api?words=1&length=4'
+  )
+  const gameCode = (await response.json())[0]
 
   kv.set(gameCode, gameId)
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -14,6 +14,7 @@ services:
     tty: true
     command: ./entrypoint.sh
   api:
+    platform: linux/x86_64
     image: sanicframework/sanic:latest-py3.10
     ports:
       - "6464:8000" # 8000 is the default Sanic port


### PR DESCRIPTION
Found a nice API that returns random 4 letter words. Switches the game code generation to use this API instead of creating random 4 character strings for improved share-ability.

